### PR TITLE
Simplify the implementation

### DIFF
--- a/docs/pages/01-basics.md
+++ b/docs/pages/01-basics.md
@@ -1,14 +1,17 @@
 # Basics
 
-Most of what is to be done is self explanatory from the [Quick Copy](/#quick-copy) example
-but let's get into explaining what can and cannot be done
+Most of what is to be done is self explanatory from the
+[Quick Copy](/#quick-copy) example but let's get into explaining what can and
+cannot be done
 
 ## State
 
-Unlike react, a state in mage is any variable that can be edited and or modified and is supposed to re-render post that modification.
-Similar to react, every state change will cause a re-render so are to be done when necessary.
+Unlike react, a state in mage is any variable that can be edited and or modified
+and is supposed to re-render post that modification. Similar to react, every
+state change will cause a re-render so are to be done when necessary.
 
-> **Note**: mage uses [valtio](https://valtio.pmnd.rs) internally to handle state so the same rules as valtio apply to the state.
+> **Note**: mage uses [valtio](https://valtio.pmnd.rs) internally to handle
+> state so the same rules as valtio apply to the state.
 
 Here's how you create and handle state
 
@@ -24,11 +27,13 @@ const state = createState({
 state.someStatefulVariableName = 'hello world'
 ```
 
-Unless connected to a component, the above will make no difference and is just going to assign itself the new value, in this case `hello world`
+Unless connected to a component, the above will make no difference and is just
+going to assign itself the new value, in this case `hello world`
 
 ## Components
 
-When using mage, a component is just a view that's being returned from a function and so you need to change your thinking about how you used stateful
+When using mage, a component is just a view that's being returned from a
+function and so you need to change your thinking about how you used stateful
 components.
 
 ```js
@@ -39,8 +44,9 @@ function Component({aProp}) {
 
 ## Reactive Components
 
-Now, the whole point of the library is to keep components simple to discard and make changes to, so to make the above reactive or show
-something based on state instead of props, define the state in the same file using `createState`.
+Now, the whole point of the library is to keep components simple to discard and
+make changes to, so to make the above reactive or show something based on state
+instead of props, define the state in the same file using `createState`.
 
 ```js
 import {createState, makeReactive} from '@barelyhuman/mage'
@@ -53,52 +59,25 @@ function Component() {
 	return <p>{state.name}? Who's that?</p>
 }
 
-const ReactiveComponent = makeReactive(Component, {state})
+const ReactiveComponent = makeReactive(state)(Component)
 ```
 
-Now, all you're doing is using a function and a variable to create a reactive component that'll re-render based on changes to the state.
+Now, all you're doing is using a function and a variable to create a reactive
+component that'll re-render based on changes to the state.
 
 ### Actions
 
-Just state is not what goes into a component, the business logic is also something that's needed, now I recommend using Class components when writing such components
-where there's a ton of business logic but, mage can do that for you as well.
+Just state is not what goes into a component, the business logic is also
+something that's needed, now I recommend using Class components when writing
+such components where there's a ton of business logic but, mage can do that for
+you as well.
 
-You can use actions in 2 ways.
-
-#### Injected Actions
-
-These are actions that get passed to the component as props which you can use if you wish to keep it structured.
-
-```js
-function ComponentImpl({actions}) {
-	return (
-		<>
-			<button onClick={actions.click}> The Button! </button>
-		</>
-	)
-}
-
-// somewhere else in the file
-
-const actions = {
-	click() {
-		console.log('hello')
-		// or change state
-		state.message = 'hello'
-	},
-}
-
-const Component = makeReactive(ComponentImpl, {actions})
-```
-
-This is a good to have from mage to make it easier to split into files and still be able to pass it down to other components if needed.
-
-#### Actions as functions
-
-Since, the only requirement is for the state to be injected into the component that's going to re-render, actions can be simple functions, so the below is totally valid.
+The only requirement is for the state to be injected into the component for it to be monitored
+, everything else should be just functions, so the below is how
+you'll be defining most of the behaviour
 
 ```js
-import {makeReactive, createState} from '@barelyhuman/mage'
+import {createState, makeReactive} from '@barelyhuman/mage'
 
 const state = createState({
 	greeting: 'hello',
@@ -116,5 +95,5 @@ function ComponentImpl() {
 	)
 }
 
-const Component = makeReactive(ComponentImpl, {state})
+const Component = makeReactive(state)(ComponentImpl)
 ```

--- a/docs/pages/01-basics.md
+++ b/docs/pages/01-basics.md
@@ -33,7 +33,7 @@ going to assign itself the new value, in this case `hello world`
 ## Components
 
 When using mage, a component is just a view that's being returned from a
-function and so you need to change your thinking about how you used stateful
+function and so you need to change your thinking about how you use stateful
 components.
 
 ```js
@@ -44,9 +44,18 @@ function Component({aProp}) {
 
 ## Reactive Components
 
-Now, the whole point of the library is to keep components simple to discard and
-make changes to, so to make the above reactive or show something based on state
-instead of props, define the state in the same file using `createState`.
+The library tries to make it a habit for developers to write disposable and reusable
+components that aren't bound to 100's of stuff just because of how react works right now.
+
+We do this by separating the 2 base requirements of a UI component
+
+1. State
+2. Functional Logic / Business Logic
+
+When working with mage, you define state away from the actual component
+and connect it to the component using the `makeReactive` utility.
+
+State can be defined by using `createState` as shown below.
 
 ```js
 import {createState, makeReactive} from '@barelyhuman/mage'
@@ -62,19 +71,20 @@ function Component() {
 const ReactiveComponent = makeReactive(state)(Component)
 ```
 
-Now, all you're doing is using a function and a variable to create a reactive
-component that'll re-render based on changes to the state.
-
 ### Actions
 
-Just state is not what goes into a component, the business logic is also
-something that's needed, now I recommend using Class components when writing
-such components where there's a ton of business logic but, mage can do that for
-you as well.
+Next up, is the business logic.
 
-The only requirement is for the state to be injected into the component for it to be monitored
-, everything else should be just functions, so the below is how
-you'll be defining most of the behaviour
+We recommend using Class components when writing
+such components where there's a ton of business logic but since we've abstracted the state
+away from the component, business logic can be just simple functions that are passed values from
+inside the component.
+
+> **Note**: pass the needed values to the functions from inside the component as parameters where
+> necessary, use state only for values that should cause a re-render and **not** for everything you
+> wish for both the function and component to share
+
+**Example**
 
 ```js
 import {createState, makeReactive} from '@barelyhuman/mage'

--- a/docs/pages/02-lifecycle.md
+++ b/docs/pages/02-lifecycle.md
@@ -1,11 +1,11 @@
 # Lifecycle
 
-Component lifecycle is basically a way to control what happens when a component
-is mounted and when unmounted.
+Lifecycle control is another part which cannot be avoided with a SPA (Single Page App), since
+a lot of data fetching and initial logic comes into play here.
 
-Now in most cases all you need is those 2 states, and I'd like to move away from
-the "side-effect of a change" mentality so that's all that this library
-provides.
+Once you start using mage, there needs to be a slight mentality shift since there's no more
+side-effect based changes , and the only lifecycle phases you have control over is the mount and
+unmount of a component.
 
 ```js
 import {makeReactive} from '@barelyhuman/mage'
@@ -21,17 +21,58 @@ Component.onDestroy((props) => {
 })
 ```
 
-A defined method helps you locate each action easily and you can have multiple
-such methods make smaller more manageable chunks, but it's **highly
+A defined method (eg: `onMount`) helps you locate each action easily and you can have multiple
+such methods to make smaller more manageable chunks, but it's **highly
 recommended** to just add one `onMount` and `onDestroy` per component
 
 You get the `props` passed to you in both cases which are what are initially
 passed to the component since you might need to use the initial props to modify
 the state with certain amount of data.
 
-**But what if I wish to do something when the props changes?**
+**What if I wish to do something when the props changes?**
 
 Your components are pure functions, they'll re-render on prop changes
 automatically, it's never good to keep prop in sync with state, the state and
-props play different roles in react, you might have to refactor how you handle
-this situation.
+props play different roles in react, you should refactor how you write your component
+in this case
+
+**What if a state changes and I wish that to trigger an effect?**
+You trigger the function after the state change and pass it the changed state.
+This keeps the effects in a single place and easier to modify and look for later than
+running through 10 different `useEffect` each handling it's own set of dependencies
+which cause 10 different render actions and makes it easier to make mistakes.
+
+**example**
+If I wish to create an `alert` everytime I change count, here's how I'd write it.
+
+```js
+const counterState = createState({count: 0})
+
+const withCounterState = makeReactive(counterState)
+
+function inc() {
+	counterState.count += 1
+	showAlert(counterState.count)
+}
+
+function showAlert(count) {
+	alert('count increased', count)
+}
+
+function Component() {
+	return (
+		<>
+			<p>{counterState.count}</p>
+			<button onClick={inc}>Inc</button>
+		</>
+	)
+}
+
+const ReactiveComponent = withCounterState(Component)
+```
+
+For functional programming lovers, you now have a way to keep the following separate without creating a lot of noise inside the component.
+
+- pure functional components - render what's given and have functional triggers to change the view
+- pure functions - same result on same parameters (`showAlert` in the above example)
+- sideeffect functions - functions that change the state , and mostly what's the components use to trigger changes to state

--- a/docs/pages/02-lifecycle.md
+++ b/docs/pages/02-lifecycle.md
@@ -1,30 +1,37 @@
 # Lifecycle
 
-Component lifecycle is basically a way to control what happens
-when a component is mounted and when unmounted, so the reactive
-components will in most cases, need a way to define behaviour when
-a component mounts and when it unmounts.
+Component lifecycle is basically a way to control what happens when a component
+is mounted and when unmounted.
 
-Now in most cases all you need is mount and unmount and I'd like to move away from the side-effect of a change mentality so that's all that this library provides.
+Now in most cases all you need is those 2 states, and I'd like to move away from
+the "side-effect of a change" mentality so that's all that this library
+provides.
 
 ```js
 import {makeReactive} from '@barelyhuman/mage'
 
-makeReactive(() => <></>, {
-	state,
-	actions,
-	injections,
-	onMount({state, actions, injections, props}) {
-		console.log("I've mounted")
-	},
-	onDestroy({state, actions, injections, props}) {
-		console.log('hello darkness, my old friend!')
-	},
+const Component = makeReactive(state)(() => <></>)
+
+Component.onMount((props) => {
+	console.log("I've mounted")
+})
+
+Component.onDestroy((props) => {
+	console.log('hello darkness, my old friend!')
 })
 ```
 
-You get the `state, actions, injections, props` passed to you in both cases
-since you might need to use the initial props while doing something.
+A defined method helps you locate each action easily and you can have multiple
+such methods make smaller more manageable chunks, but it's **highly
+recommended** to just add one `onMount` and `onDestroy` per component
+
+You get the `props` passed to you in both cases which are what are initially
+passed to the component since you might need to use the initial props to modify
+the state with certain amount of data.
 
 **But what if I wish to do something when the props changes?**
-Valid point, a `onPropChange` is in the works
+
+Your components are pure functions, they'll re-render on prop changes
+automatically, it's never good to keep prop in sync with state, the state and
+props play different roles in react, you might have to refactor how you handle
+this situation.

--- a/docs/pages/03-injections.md
+++ b/docs/pages/03-injections.md
@@ -1,11 +1,13 @@
 # Injections
 
-Now, this is a "**good to have**" for all the libraries that only support hooks
-and so while I do not recommend using these libraries at all but there's
-definitely libraries that are necessary and that leaves us with no viable
-options so, in that case, you can use injections which take in a key,function
-pair. the function is to return another function in a hook form, similar to how you'd be declaring
-a custom hook
+This is a "**good to have**" for libraries that only provide hooks and so you don't have to trash your entire
+component but be able to slowly add `mage` as a disciplinary library while writing components
+and so while we do not recommend using these libraries, sometimes there's no other viable option.
+
+In which case, it's easier to just use the hooks they provide to inject them (pass them) to the
+reactive component and the reactive component only.
+
+The state and injections are kept separate to make sure you can reuse your state connector later.
 
 Eg:
 

--- a/docs/pages/03-injections.md
+++ b/docs/pages/03-injections.md
@@ -1,34 +1,17 @@
 # Injections
 
-These are basically things that can be injected to a reactive component instance.
-
-1. State (mandatory)
-2. Actions (optional)
-3. Injections (optional, hook based injections)
-
-## State
-
-This injection is mandatory for reactive components, you don't need it to be reactive otherwise.
-
-## Actions
-
-These as mentioned in the [basics#actions](01-basics#actions) is optional and
-can be done without it if you aren't really doing any state manipulation in which
-case the component instance should be wrapped with `makeReactive` and the state
-being manipulated needs to be injected into it.
-
-## Injections
-
-Now, this is for all the libraries that only support hooks and so while I do not recommend using these libraries at all but there's definitely libraries that are necessary and there's no other viable option so.
-
-In that case, you can use injections which take in a key,function pair.
-the function is to return another function in a hook form.
+Now, this is a "**good to have**" for all the libraries that only support hooks
+and so while I do not recommend using these libraries at all but there's
+definitely libraries that are necessary and that leaves us with no viable
+options so, in that case, you can use injections which take in a key,function
+pair. the function is to return another function in a hook form, similar to how you'd be declaring
+a custom hook
 
 Eg:
 
 ```js
 const injections = {
-	// redux is only an example here, you can use the `connect` api
+	// redux is only an example here, you should be able to the `connect` api
 	somethingFromRedux: () => {
 		return () => {
 			const userProfile = useSelector((s) => s.user.profile)
@@ -43,5 +26,7 @@ function ComponentImpl({injections}) {
 	return <>{injections.somethingFromRedux.displayName}</>
 }
 
-const Component = makeReactive(ComponentImpl, {injections})
+const Component = makeReactive({})(ComponentImpl)
+
+Component.inject(injections)
 ```

--- a/docs/pages/04-api.md
+++ b/docs/pages/04-api.md
@@ -1,0 +1,57 @@
+# API Reference
+
+#### createState
+
+Takes in an object for the initial state and returns the same state as mutable state of the same structure
+
+```ts
+function createState<S extends object>(intitial: S): S
+```
+
+#### makeReactive
+
+A curried function (or a function that returns another function) that takes in the state and the component that is supposed to listen to the state's changes.
+
+```ts
+function makeReactive<S extends object>(
+	state: S
+): <Props>(
+	Component: React.FC<
+		Props & {
+			state: S
+			injections: Record<string, unknown>
+		}
+	>
+) => {
+	({...props}: Props): JSX.Element
+	onMount(fn: HookFunc<Props>): void
+	onDestroy(fn: HookFunc<Props>): void
+	inject(injections: Record<string, WrappedReactHook<Props>>): void
+}
+```
+
+**Examples**
+
+```ts
+const greetingState = createState({greeting: 'hello'})
+
+const connectGreetingState = makeReactive(greetingState)
+
+function Component() {
+	return <> {greetingState.greeting} ,world</>
+}
+
+const ReactiveComponent = connectGreetingState(Component)
+
+ReactiveComponent.onMount(() => {
+	// will execute post mount
+})
+
+ReactiveComponent.onDestroy(() => {
+	// will execute pre destroy
+})
+
+ReactiveComponent.inject({
+	// .. inject data or handlers from other hooks
+})
+```

--- a/examples/01_minimal/package.json
+++ b/examples/01_minimal/package.json
@@ -1,0 +1,24 @@
+{
+	"name": "mage-minimal-example",
+	"version": "0.1.0",
+	"private": true,
+	"dependencies": {
+		"valtio": "latest",
+		"@barelyhuman/mage": "latest",
+		"react": "latest",
+		"react-dom": "latest",
+		"react-scripts": "latest"
+	},
+	"scripts": {
+		"start": "react-scripts start",
+		"build": "react-scripts build",
+		"test": "react-scripts test",
+		"eject": "react-scripts eject"
+	},
+	"browserslist": [
+		">0.2%",
+		"not dead",
+		"not ie <= 11",
+		"not op_mini all"
+	]
+}

--- a/examples/01_minimal/public/index.html
+++ b/examples/01_minimal/public/index.html
@@ -1,0 +1,8 @@
+<html>
+  <head>
+    <title>mage example</title>
+  </head>
+  <body>
+    <div id="app"></div>
+  </body>
+</html>

--- a/examples/01_minimal/src/index.js
+++ b/examples/01_minimal/src/index.js
@@ -1,0 +1,33 @@
+import React from 'react'
+import {createRoot} from 'react-dom/client'
+import {proxy} from 'valtio'
+import {makeReactive} from '@barelyhuman/mage'
+
+const state = proxy({
+	count: 0,
+})
+
+function inc() {
+	state.count += 1
+}
+
+function CounterImpl() {
+	return (
+		<>
+			<p>{state.count}</p>
+			<button onClick={inc}>+</button>
+		</>
+	)
+}
+
+const Counter = makeReactive(state)(CounterImpl)
+
+const App = () => {
+	return (
+		<div>
+			<Counter />
+		</div>
+	)
+}
+
+createRoot(document.getElementById('app')).render(<App />)

--- a/examples/02_basic_api/package.json
+++ b/examples/02_basic_api/package.json
@@ -1,0 +1,24 @@
+{
+	"name": "mage-minimal-example",
+	"version": "0.1.0",
+	"private": true,
+	"dependencies": {
+		"valtio": "latest",
+		"@barelyhuman/mage": "latest",
+		"react": "latest",
+		"react-dom": "latest",
+		"react-scripts": "latest"
+	},
+	"scripts": {
+		"start": "react-scripts start",
+		"build": "react-scripts build",
+		"test": "react-scripts test",
+		"eject": "react-scripts eject"
+	},
+	"browserslist": [
+		">0.2%",
+		"not dead",
+		"not ie <= 11",
+		"not op_mini all"
+	]
+}

--- a/examples/02_basic_api/public/index.html
+++ b/examples/02_basic_api/public/index.html
@@ -1,0 +1,8 @@
+<html>
+  <head>
+    <title>mage example</title>
+  </head>
+  <body>
+    <div id="app"></div>
+  </body>
+</html>

--- a/examples/02_basic_api/src/index.js
+++ b/examples/02_basic_api/src/index.js
@@ -1,0 +1,50 @@
+import React from 'react'
+import {createRoot} from 'react-dom/client'
+import {proxy} from 'valtio'
+import {makeReactive} from '@barelyhuman/mage'
+import {useState} from 'react'
+
+const state = proxy({
+	count: 0,
+})
+
+function inc() {
+	state.count += 1
+}
+
+function CounterImpl({injections}) {
+	return (
+		<>
+			<p>{state.count}</p>
+			<button onClick={inc}>+</button>
+
+			<section>
+				<h4>Injected Data</h4>
+				<p>{`injections.name: ${injections.name}`}</p>
+			</section>
+		</>
+	)
+}
+
+const Counter = makeReactive(state)(CounterImpl)
+
+Counter.onMount((props) => {
+	state.count = props.initial
+})
+
+Counter.inject({
+	name: () => () => {
+		const [name] = useState('Reaper')
+		return name
+	},
+})
+
+const App = () => {
+	return (
+		<div>
+			<Counter initial={2} />
+		</div>
+	)
+}
+
+createRoot(document.getElementById('app')).render(<App />)

--- a/package.json
+++ b/package.json
@@ -45,9 +45,11 @@
 	],
 	"devDependencies": {
 		"@mvllow/tsconfig": "^0.1.0",
+		"@testing-library/react": "^13.3.0",
 		"@types/node": "^17.0.45",
 		"@types/react": "^18.0.17",
 		"ava": "^4.2.0",
+		"browser-env": "^3.3.0",
 		"bumpp": "^8.2.1",
 		"del-cli": "^4.0.1",
 		"html-webpack-plugin": "^5.5.0",
@@ -58,6 +60,7 @@
 		"style-loader": "^3.3.1",
 		"ts-loader": "^9.3.1",
 		"ts-node": "^10.7.0",
+		"tsm": "^2.2.2",
 		"typescript": "^4.7.4",
 		"valtio": "^1.6.3",
 		"webpack": "^5.72.0",
@@ -77,10 +80,14 @@
 	},
 	"ava": {
 		"extensions": {
-			"ts": "module"
+			"ts": "module",
+			"tsx": "module"
 		},
 		"nodeArguments": [
 			"--loader=ts-node/esm"
+		],
+		"require": [
+			"tsm"
 		]
 	},
 	"peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,9 @@
 		"test": "ava",
 		"release": "np",
 		"version": "npm run build",
-		"next": "bumpp"
+		"next": "bumpp",
+		"examples:01_minimal": "DIR=01_minimal EXT=js webpack serve",
+		"examples:02_basic_api": "DIR=02_basic_api EXT=js webpack serve"
 	},
 	"files": [
 		"dist"
@@ -48,12 +50,19 @@
 		"ava": "^4.2.0",
 		"bumpp": "^8.2.1",
 		"del-cli": "^4.0.1",
+		"html-webpack-plugin": "^5.5.0",
 		"np": "^7.6.1",
 		"prettier": "^2.6.2",
-		"react": "^18.2.0",
+		"react": "^18.0.0",
+		"react-dom": "^18.0.0",
+		"style-loader": "^3.3.1",
+		"ts-loader": "^9.3.1",
 		"ts-node": "^10.7.0",
 		"typescript": "^4.7.4",
 		"valtio": "^1.6.3",
+		"webpack": "^5.72.0",
+		"webpack-cli": "^4.9.2",
+		"webpack-dev-server": "^4.8.1",
 		"xo": "^0.48.0"
 	},
 	"prettier": {
@@ -75,7 +84,7 @@
 		]
 	},
 	"peerDependencies": {
-		"react": "^18.2.0",
+		"react": "^18.0.0",
 		"valtio": "^1.6.3"
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,8 @@
 
 ## Usage
 
-> **Note**: The library uses `valtio` internally to make it easier to make state as just simple mutations on the `state` variable
+> **Note**: The library depends on `valtio`, so please install valtio as well
+> (ignore if already installed)
 
 ```sh
 npm install @barelyhuman/mage valtio
@@ -19,30 +20,36 @@ pnpm add @barelyhuman/mage valtio
 ```js
 import {createState, makeReactive} from '@barelyhuman/mage'
 
-const state = createState({count: 0})
-const actions = {
-	inc() {
-		state.count += 1
-	},
+const state = createState({
+	count: 0,
+})
+
+function inc() {
+	state.count += 1
 }
 
-function ComponentImpl() {
+function CounterImpl() {
 	return (
 		<>
 			<p>{state.count}</p>
-			<button onClick={actions.inc}>+</button>
+			<button onClick={inc}>+</button>
 		</>
 	)
 }
 
-const Component = makeReactive(ComponentImpl, {state, actions})
+const Component = makeReactive(state)(CounterImpl)
 
 export default Component
 ```
 
 ## About
 
-> **Note**: This library isn't a mandatory requirement, most of what it does can be done by using something like [valtio](https://valtio.pmnd.rs) or [jotai](http://jotai.org) and maintaining local state in the component file and not inside the component and side effects being thrown out of your head and using manual action based triggers inside other actions. (how you'd write normal javascript)
+> **Note**: This library isn't a mandatory requirement, most of what it does can
+> be done by using something like [valtio](https://valtio.pmnd.rs) or
+> [jotai](http://jotai.org) and maintaining local state in the component file
+> and not inside the component and side effects being thrown out of your head
+> and using manual action based triggers inside other actions. (how you'd write
+> normal javascript)
 
 The reason for mage to exist was to abstract and block the usage of hooks in
 functional components. This became necessary after libraries dropping support
@@ -66,7 +73,8 @@ This is where it's necessary for that abstraction to be taken up by a utility.
 ## Docs
 
 You can read more about the usage and API by checking the
-[docs/pages](docs/pages) folder in the repo or by visiting the [web version &rarr;](https://barelyhuman.github.io/mage/)
+[docs/pages](docs/pages) folder in the repo or by visiting the
+[web version &rarr;](https://barelyhuman.github.io/mage/)
 
 ## Disclaimer
 

--- a/source/index.tsx
+++ b/source/index.tsx
@@ -5,7 +5,7 @@ type HookFunc<Props> = (props: Props) => void
 
 type WrappedReactHook<Props> = (props: Props) => () => any
 
-export function createReactive<S extends object>(state: S) {
+export function makeReactive<S extends object>(state: S) {
 	return function createWrapper<Props>(
 		Component: React.FC<Props & {state: S; injections: Record<string, unknown>}>
 	) {
@@ -26,13 +26,14 @@ export function createReactive<S extends object>(state: S) {
 			}
 
 			useEffect(() => {
+				const unsub = subscribe(state, () => {
+					s[1]({})
+				})
+
 				mountFuncs.forEach((x) => {
 					x(props)
 				})
 
-				const unsub = subscribe(state, () => {
-					s[1]({})
-				})
 				return () => {
 					unMountFuncs.forEach((x) => {
 						x(props)
@@ -50,7 +51,7 @@ export function createReactive<S extends object>(state: S) {
 			unMountFuncs.push(fn)
 		}
 
-		Wrapper.injections = (
+		Wrapper.inject = (
 			injections: Record<string, WrappedReactHook<Props>>
 		) => {
 			_injections = injections

--- a/source/index.tsx
+++ b/source/index.tsx
@@ -1,9 +1,13 @@
 import React, {useEffect, useState} from 'react'
-import {subscribe} from 'valtio'
+import {proxy, subscribe} from 'valtio'
 
 type HookFunc<Props> = (props: Props) => void
 
 type WrappedReactHook<Props> = (props: Props) => () => any
+
+export function createState<S extends object>(intitial: S) {
+	return proxy(intitial)
+}
 
 export function makeReactive<S extends object>(state: S) {
 	return function createWrapper<Props>(
@@ -51,9 +55,7 @@ export function makeReactive<S extends object>(state: S) {
 			unMountFuncs.push(fn)
 		}
 
-		Wrapper.inject = (
-			injections: Record<string, WrappedReactHook<Props>>
-		) => {
+		Wrapper.inject = (injections: Record<string, WrappedReactHook<Props>>) => {
 			_injections = injections
 		}
 

--- a/source/index.tsx
+++ b/source/index.tsx
@@ -1,131 +1,61 @@
 import React, {useEffect, useState} from 'react'
-import {proxy, subscribe} from 'valtio'
+import {subscribe} from 'valtio'
 
-export function createState<State extends object>(initial: State) {
-	return proxy(initial)
-}
+type HookFunc<Props> = (props: Props) => void
 
-export type Context<State, Actions, Injections> = {
-	state: State
-	actions?: Actions
-	injections?: Injections
-}
+type WrappedReactHook<Props> = (props: Props) => () => any
 
-export type ContextWithProps<State, Actions, Injections> = Context<
-	State,
-	Actions,
-	Injections
-> & {props?: any}
+export function createReactive<S extends object>(state: S) {
+	return function createWrapper<Props>(
+		Component: React.FC<Props & {state: S; injections: Record<string, unknown>}>
+	) {
+		let mountFuncs: HookFunc<Props>[] = []
+		let unMountFuncs: HookFunc<Props>[] = []
+		let _injections: Record<string, WrappedReactHook<Props>> = {}
+		let injectedData: Record<string, unknown> = {}
 
-export type ContextWithArbitraryRecords<State, Actions, Injections> = Context<
-	State,
-	Actions,
-	Injections
-> &
-	Record<string, any>
+		function Wrapper({...props}: Props) {
+			const s = useState({})
 
-export type ReactiveParameters<State, Actions, Injections> = {
-	state: State
-	actions?: Actions
-	injections?: Injections
-	onMount?: (ctx: ContextWithProps<State, Actions, Injections>) => void
-	onDestroy?: (ctx: ContextWithProps<State, Actions, Injections>) => void
-}
-
-type HookWrapper<State, Actions, Injections> = (
-	ctx: ContextWithProps<State, Actions, Injections>
-) => () => any
-
-export function makeReactive<
-	State extends object,
-	Actions,
-	Injections extends Record<string, HookWrapper<State, Actions, Injections>>
->(
-	Component: React.FC<ContextWithArbitraryRecords<State, Actions, Injections>>,
-	{
-		state,
-		actions,
-		injections,
-		onMount,
-		onDestroy,
-	}: ReactiveParameters<State, Actions, Injections>
-) {
-	const mountFuncs = [onMount].filter((x) => x)
-	const unmountFuncs = [onDestroy].filter((x) => x)
-	const _injections: Injections = {} as Injections
-	const userInjections: Injections = injections ?? ({} as Injections)
-
-	const injectKeys: string[] = Object.keys(userInjections)
-
-	function Wrapper({...props}) {
-		const s = useState({})
-		const ctx: Context<State, Actions, Injections> = {
-			state,
-			actions,
-			injections,
-		}
-
-		for (const key of injectKeys) {
-			if (key) {
-				const injection = userInjections[key]
-				if (
-					typeof injection === 'function' &&
-					typeof injection(ctx) === 'function'
-				) {
-					// @ts-expect-error unable to index a record of type string with key of type string, TS bug?
-					// FIXME: need to debug the above
-					_injections[key] = injection(ctx)()
-				}
-			}
-		}
-
-		useEffect(() => {
-			let unsub: () => void
-			if (state) {
-				unsub = subscribe(state, () => {
-					s[1]({})
-				})
-			}
-
-			for (const onMountCalls of mountFuncs) {
-				if (!(onMountCalls && typeof onMountCalls === 'function')) {
+			for (const key in _injections) {
+				const hookWrapper = _injections[key]
+				if (!(hookWrapper && typeof hookWrapper === 'function')) {
 					continue
 				}
+				injectedData[key] = hookWrapper(props)()
+			}
 
-				onMountCalls({
-					state,
-					actions,
-					injections: _injections as Injections,
-					props,
+			useEffect(() => {
+				mountFuncs.forEach((x) => {
+					x(props)
 				})
-			}
 
-			return () => {
-				unsub?.()
-				for (const onDestroyCalls of unmountFuncs) {
-					if (!(onDestroyCalls && typeof onDestroyCalls === 'function')) {
-						continue
-					}
-
-					onDestroyCalls({
-						state,
-						actions,
-						injections: _injections as Injections,
-						props,
+				const unsub = subscribe(state, () => {
+					s[1]({})
+				})
+				return () => {
+					unMountFuncs.forEach((x) => {
+						x(props)
 					})
+					unsub()
 				}
-			}
-		}, [])
+			}, [])
+			return <Component state={state} injections={injectedData} {...props} />
+		}
 
-		return (
-			<Component
-				state={state}
-				actions={actions}
-				injections={_injections as Injections}
-				{...props}
-			/>
-		)
+		Wrapper.onMount = (fn: HookFunc<Props>) => {
+			mountFuncs.push(fn)
+		}
+		Wrapper.onDestroy = (fn: HookFunc<Props>) => {
+			unMountFuncs.push(fn)
+		}
+
+		Wrapper.injections = (
+			injections: Record<string, WrappedReactHook<Props>>
+		) => {
+			_injections = injections
+		}
+
+		return Wrapper
 	}
-
-	return Wrapper
 }

--- a/test/main.ts
+++ b/test/main.ts
@@ -1,5 +1,0 @@
-import test from 'ava'
-
-test('main', (t) => {
-	t.pass()
-})

--- a/test/states.test.tsx
+++ b/test/states.test.tsx
@@ -1,0 +1,83 @@
+//@ts-ignore
+import browserEnv from 'browser-env'
+
+import React from 'react'
+import test from 'ava'
+import {createState, makeReactive} from '../source/index.jsx'
+import {fireEvent, render, waitFor, cleanup} from '@testing-library/react'
+
+browserEnv()
+
+test.afterEach(() => {
+	cleanup()
+})
+
+test.serial('should display a stateless component', async (t) => {
+	function Component() {
+		return <p id="test">hello</p>
+	}
+
+	const ReactiveComponent = makeReactive(createState({}))(Component)
+
+	const {getByText} = render(<ReactiveComponent />)
+	getByText('hello')
+	t.pass()
+})
+
+test.serial('should add 1 additional render on state change', async (t) => {
+	const state = createState({count: 0})
+	let renders = 0
+
+	function inc() {
+		state.count += 1
+	}
+
+	function Component() {
+		renders += 1
+		return (
+			<>
+				<p>{state.count}</p>
+				<button onClick={inc}>inc</button>
+			</>
+		)
+	}
+
+	const ReactiveComponent = makeReactive(state)(Component)
+
+	const {getByText} = render(<ReactiveComponent />)
+
+	let initialRender = renders
+
+	fireEvent.click(getByText('inc'))
+	await waitFor(() => getByText('1'))
+	if (renders - initialRender > 1) {
+		t.fail()
+		return
+	}
+
+	t.pass()
+	return
+})
+
+test.serial('should take state from the onMount value', async (t) => {
+	const state = createState({count: 0})
+	let onMountValue = 10
+	function Component() {
+		return (
+			<>
+				<p>{state.count}</p>
+			</>
+		)
+	}
+	const ReactiveComponent = makeReactive(state)(Component)
+	ReactiveComponent.onMount((_) => {
+		state.count = onMountValue
+	})
+	const {getByText} = render(<ReactiveComponent />)
+	// need to wait for a mount and then re-render before it changes to the
+	// given mounted value
+	const elm = await waitFor(() => getByText(onMountValue))
+	t.assert('' + onMountValue, elm.innerText)
+})
+
+

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -1,0 +1,47 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const HtmlWebpackPlugin = require('html-webpack-plugin')
+
+const {DIR, EXT = 'ts'} = process.env
+
+module.exports = {
+	mode: 'development',
+	devtool: 'cheap-module-source-map',
+	entry: `./examples/${DIR}/src/index.${EXT}`,
+	output: {
+		publicPath: '/',
+	},
+	plugins: [
+		new HtmlWebpackPlugin({
+			template: `./examples/${DIR}/public/index.html`,
+		}),
+	],
+	module: {
+		rules: [
+			{
+				test: /\.[jt]sx?$/,
+				exclude: /node_modules/,
+				loader: 'ts-loader',
+				options: {
+					transpileOnly: true,
+				},
+			},
+			{
+				test: /\.css$/i,
+				use: ['style-loader', 'css-loader'],
+			},
+		],
+	},
+	resolve: {
+		extensions: ['.js', '.jsx', '.ts', '.tsx'],
+		alias: {
+			'@barelyhuman/mage': `${__dirname}/source`,
+		},
+	},
+	devServer: {
+		port: process.env.PORT || '8080',
+		static: {
+			directory: `./examples/${DIR}/public`,
+		},
+		historyApiFallback: true,
+	},
+}


### PR DESCRIPTION
Another attempt to make the implementation simple enough to be maintainable later 

forcing everything to be functions other than maybe injections from mandatory hooks

- [x] Base implementation
- [x] type defs
- [x] update docs with the new API and explanations
- [x] example code 
- [x] tests for it 